### PR TITLE
[skip ci] Closes #19

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -17,8 +17,8 @@ on:
 
 jobs:
   build:
+    if: ${{ github.repository == 'i-RIC/iricdev-2019' }} 
     runs-on: windows-latest
-
     steps:
       - name: REST-API
         run: |


### PR DESCRIPTION
 Only builds from the i-RIC/iricdev-2019 repository (not a fork).